### PR TITLE
Disable Typebot streaming

### DIFF
--- a/backend/src/services/TypebotServices/typebotListener.ts
+++ b/backend/src/services/TypebotServices/typebotListener.ts
@@ -48,7 +48,7 @@ const typebotListener = async ({
             const id = Math.floor(Math.random() * 10000000000).toString();
 
             const reqData = JSON.stringify({
-                "isStreamEnabled": true,
+                "isStreamEnabled": false,
                 "message": "string",
                 "resultId": "string",
                 "isOnlyRegistering": false,


### PR DESCRIPTION
## Summary
- disable streaming in Typebot `startChat` request

## Testing
- `npm test` *(fails: sequelize not found)*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_68422cb0102c8323aff55004decd8e31